### PR TITLE
Add missing attachment fields

### DIFF
--- a/discord_http/file.py
+++ b/discord_http/file.py
@@ -14,10 +14,16 @@ class File:
         *,
         filename: Optional[str] = None,
         spoiler: bool = False,
-        description: Optional[str] = None
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        duration_secs: Optional[int] = None,
+        waveform: Optional[str] = None
     ):
         self.spoiler = spoiler
+        self.title = title
         self.description = description
+        self.duration_secs = duration_secs
+        self.waveform = waveform
         self._filename = filename
 
         if isinstance(data, io.IOBase):
@@ -68,7 +74,13 @@ class File:
             "filename": self.filename
         }
 
+        if self.title:
+            payload["title"] = self.title
         if self.description:
             payload["description"] = self.description
+        if self.duration_secs:
+            payload["duration_secs"] = self.duration_secs
+        if self.waveform:
+            payload["waveform"] = self.waveform
 
         return payload

--- a/discord_http/message.py
+++ b/discord_http/message.py
@@ -416,11 +416,16 @@ class Attachment:
         self.ephemeral: bool = data.get("ephemeral", False)
 
         self.content_type: Optional[str] = data.get("content_type", None)
+        self.title: Optional[str] = data.get("title", None)
         self.description: Optional[str] = data.get("description", None)
 
         self.height: Optional[int] = data.get("height", None)
         self.width: Optional[int] = data.get("width", None)
         self.ephemeral: bool = data.get("ephemeral", False)
+
+        self.duration_secs: Optional[int] = data.get("duration_secs", None)
+        self.waveform: Optional[str] = data.get("waveform", None)
+        self.flags: int = data.get("flags", 0)
 
     def __str__(self) -> str:
         return self.filename or ""
@@ -536,8 +541,11 @@ class Attachment:
             "url": self.url,
             "proxy_url": self.proxy_url,
             "spoiler": self.is_spoiler(),
+            "flags": self.flags
         }
 
+        if self.title is not None:
+            data["title"] = self.title
         if self.description is not None:
             data["description"] = self.description
         if self.height:
@@ -546,6 +554,10 @@ class Attachment:
             data["width"] = self.width
         if self.content_type:
             data["content_type"] = self.content_type
+        if self.duration_secs:
+            data["duration_secs"] = self.duration_secs
+        if self.waveform:
+            data["waveform"] = self.waveform
 
         return data
 


### PR DESCRIPTION
Adds support for [attachment](https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure) `flags`, `title`, `duration_secs` and `waveform`