### PR TITLE
Support for ActivityType.custom

### DIFF
--- a/discord_http/gateway/object.py
+++ b/discord_http/gateway/object.py
@@ -53,11 +53,13 @@ class PlayingStatus:
         status: StatusType | str | int | None = None,
         type: ActivityType | str | int | None = None,  # noqa: A002
         url: str | None = None,
+        state: str | None = None,
     ):
         self.since: int | None = None
         self.name = name
         self.status: StatusType | str | int | None = status
         self.type: ActivityType | str | int | None = type
+        self.state = state
 
         if isinstance(self.status, str):
             self.status = StatusType[self.status]
@@ -103,6 +105,14 @@ class PlayingStatus:
             if self.type is None:
                 # Fallback to playing if no type is provided but name is
                 payload["activities"][0]["type"] = int(ActivityType.playing)
+
+        if self.type == ActivityType.custom:
+            payload["activities"][0]["name"] = "Custom Status"
+
+            if self.state is not None:
+                payload["activities"][0]["state"] = self.state
+            elif self.name is not None:
+                payload["activities"][0]["state"] = self.name
 
         return payload
 


### PR DESCRIPTION
## Description

Support for Discord Activity Type ``custom``. The docs mention an emoji too but bots don't really support it and since this is part of setting ActivityStatus for the bot, I didn't include it but you can add it if you want.

<img width="237" alt="Screenshot 2025-05-07 at 11 40 34 AM" src="https://github.com/user-attachments/assets/138ecb71-2522-431c-9187-56a9ea6d2587" />


