### PR TITLE
fix: fix sticker items and add to forwards

### DIFF
--- a/discord_http/message.py
+++ b/discord_http/message.py
@@ -1510,6 +1510,7 @@ class MessageSnapshot:
         "content",
         "edited_timestamp",
         "embeds",
+        "stickers",
         "timestamp",
         "type",
     )
@@ -1539,6 +1540,12 @@ class MessageSnapshot:
 
         self.attachments: list[Attachment] = []
         """ The attachments of the message. """
+
+        self.stickers: list[PartialSticker] = [
+            PartialSticker(state=state, id=int(s["id"]), name=s["name"])
+            for s in data.get("sticker_items", [])
+        ]
+        """ The stickers of the message. """
 
         self._from_data(data)
 

--- a/discord_http/message.py
+++ b/discord_http/message.py
@@ -1541,10 +1541,7 @@ class MessageSnapshot:
         self.attachments: list[Attachment] = []
         """ The attachments of the message. """
 
-        self.stickers: list[PartialSticker] = [
-            PartialSticker(state=state, id=int(s["id"]), name=s["name"], format_type=s["format_type"])
-            for s in data.get("sticker_items", [])
-        ]
+        self.stickers: list[PartialSticker] = []
         """ The stickers of the message. """
 
         self._from_data(data)
@@ -1575,6 +1572,12 @@ class MessageSnapshot:
             self.attachments = [
                 Attachment(state=self._state, data=a)
                 for a in message["attachments"]
+            ]
+
+        if message.get("sticker_items", None):
+            self.stickers = [
+                PartialSticker(state=self._state, id=int(s["id"]), name=s["name"], format_type=s["format_type"])
+                for s in message["sticker_items"]
             ]
 
 

--- a/discord_http/message.py
+++ b/discord_http/message.py
@@ -1542,7 +1542,7 @@ class MessageSnapshot:
         """ The attachments of the message. """
 
         self.stickers: list[PartialSticker] = [
-            PartialSticker(state=state, id=int(s["id"]), name=s["name"])
+            PartialSticker(state=state, id=int(s["id"]), name=s["name"], format_type=s["format_type"])
             for s in data.get("sticker_items", [])
         ]
         """ The stickers of the message. """
@@ -1650,7 +1650,7 @@ class Message(PartialMessage):
         """ The attachments of the message. """
 
         self.stickers: list[PartialSticker] = [
-            PartialSticker(state=state, id=int(s["id"]), name=s["name"])
+            PartialSticker(state=state, id=int(s["id"]), name=s["name"], format_type=s["format_type"])
             for s in data.get("sticker_items", [])
         ]
         """ The stickers of the message. """

--- a/discord_http/sticker.py
+++ b/discord_http/sticker.py
@@ -21,9 +21,9 @@ class PartialSticker(PartialBase):
 
     __slots__ = (
         "_state",
+        "format_type",
         "guild_id",
-        "name",
-        "format_type"
+        "name"
     )
 
     def __init__(

--- a/discord_http/sticker.py
+++ b/discord_http/sticker.py
@@ -23,6 +23,7 @@ class PartialSticker(PartialBase):
         "_state",
         "guild_id",
         "name",
+        "format_type"
     )
 
     def __init__(
@@ -31,7 +32,8 @@ class PartialSticker(PartialBase):
         state: "DiscordAPI",
         id: int,  # noqa: A002
         name: str | None = None,
-        guild_id: int | None = None
+        guild_id: int | None = None,
+        format_type: int | None = 1
     ):
         super().__init__(id=int(id))
         self._state = state
@@ -41,6 +43,9 @@ class PartialSticker(PartialBase):
 
         self.guild_id: int | None = guild_id
         """ The ID of the guild this sticker is in, if any. """
+
+        self.format_type: StickerFormatType = StickerFormatType(format_type)
+        """ The format type of the sticker. """
 
     def __repr__(self) -> str:
         return f"<PartialSticker id={self.id}>"
@@ -187,7 +192,13 @@ class PartialSticker(PartialBase):
     @property
     def url(self) -> str:
         """ Returns the sticker's URL. """
-        return f"https://media.discordapp.net/stickers/{self.id}.png"
+        img_format = "png"
+        if self.format_type == StickerFormatType.gif:
+            img_format = "gif"
+        if self.format_type == StickerFormatType.lottie:
+            img_format = "json"
+
+        return f"https://media.discordapp.net/stickers/{self.id}.{img_format}"
 
 
 class Sticker(PartialSticker):
@@ -214,7 +225,8 @@ class Sticker(PartialSticker):
             state=state,
             id=int(data["id"]),
             name=data["name"],
-            guild_id=guild.id if guild else None
+            guild_id=guild.id if guild else None,
+            format_type=data["format_type"]
         )
 
         self._raw_type: int = data["type"]
@@ -224,9 +236,6 @@ class Sticker(PartialSticker):
 
         self.description: str = data["description"]
         """ The description of the sticker. """
-
-        self.format_type: StickerFormatType = StickerFormatType(data["format_type"])
-        """ The format type of the sticker. """
 
         self.pack_id: int | None = utils.get_int(data, "pack_id")
         """ The ID of the sticker pack this sticker belongs to, if any. """
@@ -250,15 +259,6 @@ class Sticker(PartialSticker):
     def type(self) -> StickerType:
         """ The type of the sticker. """
         return StickerType(self._raw_type)
-
-    @property
-    def url(self) -> str:
-        """ Returns the sticker's URL. """
-        img_format = "png"
-        if self.format_type == StickerFormatType.gif:
-            img_format = "gif"
-
-        return f"https://media.discordapp.net/stickers/{self.id}.{img_format}"
 
     async def edit(
         self,

--- a/discord_http/sticker.py
+++ b/discord_http/sticker.py
@@ -208,7 +208,6 @@ class Sticker(PartialSticker):
         "_raw_type",
         "available",
         "description",
-        "format_type",
         "pack_id",
         "sort_value",
         "tags",


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this pull request -->

[Sticker items](https://docs.discord.com/developers/resources/sticker#sticker-item-object) have format types, and also messane snapshots show these, good for getting the URL properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved sticker data handling with proper format information tracking
* Sticker format is now correctly preserved across message contexts
* Sticker URLs generate dynamically based on format type

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlexFlipnote/discord.http/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->